### PR TITLE
docs: add Fronteir AI hosted deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Can interact with pages, but use a **one-agent-do-all** approach: the same reaso
 - **Comet** handles the browsing: navigation, login walls, dynamic content, deep research
 - **Result**: Claude's coding intelligence + Perplexity's web intelligence, working together
 
+## Hosted deployment
+
+A hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hanzili-comet-mcp).
+
 ## Quick Start
 
 ### 1. Configure Claude Code


### PR DESCRIPTION
Love the project!

Adds a short note in the README that a hosted deployment is available on [Fronteir AI](https://fronteir.ai/mcp/hanzili-comet-mcp)